### PR TITLE
Update YAZ variable naming to use output of pkg-config directly

### DIFF
--- a/bfile/Makefile.am
+++ b/bfile/Makefile.am
@@ -9,11 +9,11 @@ tstmfile1_SOURCES = tstmfile1.c
 tstbfile1_SOURCES = tstbfile1.c
 tstbfile2_SOURCES = tstbfile2.c
 
-AM_CPPFLAGS = -I$(top_srcdir)/include $(YAZINC)
+AM_CPPFLAGS = -I$(top_srcdir)/include $(YAZ_CFLAGS)
 
 libidzebra_bfile_la_SOURCES = bfile.c mfile.c cfile.c commit.c cfile.h mfile.h
 
-LDADD = libidzebra-bfile.la ../util/libidzebra-util.la $(YAZLALIB)
+LDADD = libidzebra-bfile.la ../util/libidzebra-util.la $(YAZ_LIBS)
 
 clean-local:
 	-rm -fr *.log *.mf shadow

--- a/configure.ac
+++ b/configure.ac
@@ -36,7 +36,7 @@ fi
 dnl
 dnl ------ YAZ
 YAZ_INIT([server icu],[3.0.47])
-if test "$YAZVERSION" = "NONE"; then
+if test "$YAZ_VERSION" = "NONE"; then
     AC_MSG_ERROR([YAZ development libraries required])
 fi
 YAZ_DOC
@@ -173,7 +173,7 @@ fi
 AC_DEFINE([IDZEBRA_STATIC_GRS_XML],[0],[Whether module grs.xml is static])
 ZEBRA_MODULE(grs-xml,[$def], [  --enable-mod-grs-xml    XML filter (Expat based)])
 oldCPPFLAGS="$CPPFLAGS"
-CPPFLAGS="$CPPFLAGS $YAZINC"
+CPPFLAGS="$CPPFLAGS $YAZ_CFLAGS"
 AC_PREPROC_IFELSE(
    [AC_LANG_PROGRAM([[
 #if YAZ_HAVE_XSLT
@@ -288,10 +288,10 @@ echo \
   Automake:                   ${AUTOMAKE}
   Archiver:                   ${AR}
   Ranlib:                     ${RANLIB}
-  YAZ Version:                ${YAZVERSION}
-  YAZ Include:                ${YAZINC}
-  YAZ La Lib:                 ${YAZLALIB}
-  YAZ Lib:                    ${YAZLIB}
+  YAZ Version:                ${YAZ_VERSION}
+  YAZ Include:                ${YAZ_CFLAGS}
+  YAZ La Lib:                 ${YAZ_LIBS}
+  YAZ Lib:                    ${YAZ_LIBS}
   Bugreport:                  ${PACKAGE_BUGREPORT}
 
 ------------------------------------------------------------------------"

--- a/data1/Makefile.am
+++ b/data1/Makefile.am
@@ -6,5 +6,5 @@ libidzebra_data1_la_SOURCES = d1_handle.c d1_read.c d1_attset.c d1_tagset.c \
   d1_marc.c d1_write.c d1_expout.c d1_sumout.c d1_soif.c d1_prtree.c d1_if.c \
   d1_utils.c
 
-AM_CPPFLAGS=-I$(top_srcdir)/include $(YAZINC)
+AM_CPPFLAGS=-I$(top_srcdir)/include $(YAZ_CFLAGS)
 

--- a/dfa/Makefile.am
+++ b/dfa/Makefile.am
@@ -8,8 +8,8 @@ TESTS = $(check_PROGRAMS)
 
 test_dfa_SOURCES = test_dfa.c
 
-AM_CPPFLAGS = -I$(srcdir)/../include $(YAZINC)
-LDADD = libidzebra-dfa.la ../util/libidzebra-util.la $(YAZLALIB)
+AM_CPPFLAGS = -I$(srcdir)/../include $(YAZ_CFLAGS)
+LDADD = libidzebra-dfa.la ../util/libidzebra-util.la $(YAZ_LIBS)
 
 agrep_SOURCES = agrep.c
 

--- a/dict/Makefile.am
+++ b/dict/Makefile.am
@@ -5,13 +5,13 @@ check_PROGRAMS = scantest
 
 TESTS = $(check_PROGRAMS)
 
-AM_CPPFLAGS = -I$(srcdir)/../include $(YAZINC)
+AM_CPPFLAGS = -I$(srcdir)/../include $(YAZ_CFLAGS)
 
 LDADD = libidzebra-dict.la \
  ../bfile/libidzebra-bfile.la \
  ../dfa/libidzebra-dfa.la \
  ../util/libidzebra-util.la \
-  $(YAZLALIB)
+  $(YAZ_LIBS)
 
 libidzebra_dict_la_SOURCES = dopen.c dclose.c drdwr.c open.c close.c \
  insert.c lookup.c lookupec.c lookgrep.c delete.c scan.c dcompact.c \

--- a/idzebra-config-2.0.in
+++ b/idzebra-config-2.0.in
@@ -14,8 +14,8 @@ idzebra_src_root="@IDZEBRA_SRC_ROOT@"
 idzebra_build_root="@IDZEBRA_BUILD_ROOT@"
 package_suffix=@PACKAGE_SUFFIX@
 
-extralibs="@YAZLIB@ @TCL_LIBS@ @EXPAT_LIBS@ @LIBS@ "
-extralalibs="@YAZLALIB@ @TCL_LIBS@ @EXPAT_LIBS@ @LIBS@"
+extralibs="@YAZ_LIBS@ @TCL_LIBS@ @EXPAT_LIBS@ @LIBS@ "
+extralalibs="@YAZ_LIBS@ @TCL_LIBS@ @EXPAT_LIBS@ @LIBS@"
 
 usage()
 {
@@ -84,7 +84,7 @@ while test $# -gt 0; do
     shift
 done
 
-IDZEBRAINC="@ZEBRA_CFLAGS@ @YAZINC@"
+IDZEBRAINC="@ZEBRA_CFLAGS@ @YAZ_CFLAGS@"
 
 if test "$echo_source" = "yes"; then
     IDZEBRALIB="-L${idzebra_build_root}/index/.libs -lidzebra${package_suffix}"

--- a/index/Makefile.am
+++ b/index/Makefile.am
@@ -32,27 +32,27 @@ mod_grs_xml_la_LIBADD = $(zebralib) $(mod_grs_xml_la_LADD)
 
 mod_grs_marc_la_SOURCES = mod_grs_marc.c marcomp.c marcomp.h inline.c inline.h
 mod_grs_marc_la_LDFLAGS = -rpath $(modlibdir) -module -avoid-version
-mod_grs_marc_la_LADD = $(YAZLALIB)
+mod_grs_marc_la_LADD = $(YAZ_LIBS)
 mod_grs_marc_la_LIBADD = $(zebralib) $(mod_grs_marc_la_LADD)
 
 mod_safari_la_SOURCES = mod_safari.c
 mod_safari_la_LDFLAGS = -rpath $(modlibdir) -module -avoid-version
-mod_safari_la_LADD = $(YAZLALIB)
+mod_safari_la_LADD = $(YAZ_LIBS)
 mod_safari_la_LIBADD = $(zebralib) $(mod_safari_la_LADD)
 
 mod_alvis_la_SOURCES = mod_alvis.c
 mod_alvis_la_LDFLAGS = -rpath $(modlibdir) -module -avoid-version
-mod_alvis_la_LADD = $(YAZLALIB)
+mod_alvis_la_LADD = $(YAZ_LIBS)
 mod_alvis_la_LIBADD = $(zebralib) $(mod_alvis_la_LADD)
 
 mod_dom_la_SOURCES = mod_dom.c
 mod_dom_la_LDFLAGS = -rpath $(modlibdir) -module -avoid-version
-mod_dom_la_LADD = $(YAZLALIB)
+mod_dom_la_LADD = $(YAZ_LIBS)
 mod_dom_la_LIBADD = $(zebralib) $(mod_dom_la_LADD)
 
 mod_text_la_SOURCES = mod_text.c
 mod_text_la_LDFLAGS = -rpath $(modlibdir) -module -avoid-version
-mod_text_la_LADD = $(YAZLALIB)
+mod_text_la_LADD = $(YAZ_LIBS)
 mod_text_la_LIBADD = $(zebralib) $(mod_text_la_LADD)
 
 modlib_LTLIBRARIES = $(SHARED_MODULE_LA) 
@@ -106,12 +106,12 @@ zebrasrv_SOURCES = zebrasrv.c
 zebrash_SOURCES = zebrash.c
 kdump_SOURCES = kdump.c
 
-AM_CPPFLAGS = -I$(srcdir)/../include $(YAZINC) \
+AM_CPPFLAGS = -I$(srcdir)/../include $(YAZ_CFLAGS) \
   -DDEFAULT_PROFILE_PATH=\"$(tabdatadir)\" \
   -DDEFAULT_MODULE_PATH=\"$(modlibdir)\" \
   $(TCL_CFLAGS)
 
-LDADD = $(zebralib) $(YAZLALIB) 
+LDADD = $(zebralib) $(YAZ_LIBS) 
 
 zebrash_LDADD= $(LDADD) $(READLINE_LIBS)
 

--- a/isamb/Makefile.am
+++ b/isamb/Makefile.am
@@ -12,24 +12,24 @@ TESTS = $(check_PROGRAMS)
 tstisamb_SOURCES = tstisamb.c
 tstisamb_LDADD = libidzebra-isamb.la \
  ../bfile/libidzebra-bfile.la \
- ../util/libidzebra-util.la $(YAZLALIB)
+ ../util/libidzebra-util.la $(YAZ_LIBS)
 
 benchisamb_SOURCES = benchisamb.c
 benchisamb_LDADD = libidzebra-isamb.la \
  ../bfile/libidzebra-bfile.la \
- ../util/libidzebra-util.la $(YAZLALIB)
+ ../util/libidzebra-util.la $(YAZ_LIBS)
 
 benchindex1_SOURCES = benchindex1.c
 benchindex1_LDADD = libidzebra-isamb.la \
  ../bfile/libidzebra-bfile.la \
  ../dict/libidzebra-dict.la \
- ../util/libidzebra-util.la $(YAZLALIB)
+ ../util/libidzebra-util.la $(YAZ_LIBS)
 
 libidzebra_isamb_la_SOURCES = isamb.c
 
-AM_CPPFLAGS=-I$(srcdir)/../include $(YAZINC)
+AM_CPPFLAGS=-I$(srcdir)/../include $(YAZ_CFLAGS)
 
-LDADD = ../util/libutil.a ../bfile/libbfile.a libisamc.a $(YAZLALIB)
+LDADD = ../util/libutil.a ../bfile/libbfile.a libisamc.a $(YAZ_LIBS)
 
 clean-local:
 	-rm -rf *.LCK 

--- a/isamc/Makefile.am
+++ b/isamc/Makefile.am
@@ -3,6 +3,6 @@ noinst_LTLIBRARIES = libidzebra-isamc.la
 
 libidzebra_isamc_la_SOURCES = isamc.c merge.c isamc-p.h
 
-AM_CPPFLAGS = -I$(srcdir)/../include -I$(srcdir)/../index $(YAZINC)
+AM_CPPFLAGS = -I$(srcdir)/../include -I$(srcdir)/../index $(YAZ_CFLAGS)
 
-LDADD = ../util/libutil.a ../bfile/libbfile.a libisamc.a $(YAZLALIB)
+LDADD = ../util/libutil.a ../bfile/libbfile.a libisamc.a $(YAZ_LIBS)

--- a/isams/Makefile.am
+++ b/isams/Makefile.am
@@ -1,6 +1,6 @@
 
 noinst_LTLIBRARIES = libidzebra-isams.la
 
-AM_CPPFLAGS = -I$(srcdir)/../include $(YAZINC)
+AM_CPPFLAGS = -I$(srcdir)/../include $(YAZ_CFLAGS)
 
 libidzebra_isams_la_SOURCES = isams.c

--- a/rset/Makefile.am
+++ b/rset/Makefile.am
@@ -4,4 +4,4 @@ noinst_LTLIBRARIES = libidzebra-rset.la
 libidzebra_rset_la_SOURCES = rset.c rstemp.c rsnull.c rsbool.c rsbetween.c \
 	rsisamc.c rsmultiandor.c rsisams.c rsisamb.c rsprox.c 
 
-AM_CPPFLAGS = -I$(srcdir)/../include $(YAZINC)
+AM_CPPFLAGS = -I$(srcdir)/../include $(YAZ_CFLAGS)

--- a/test/api/Makefile.am
+++ b/test/api/Makefile.am
@@ -47,11 +47,11 @@ test_sort2_SOURCES = test_sort2.c
 test_sort3_SOURCES = test_sort3.c
 test_sortidx_SOURCES = test_sortidx.c
 
-AM_CPPFLAGS = -I$(top_srcdir)/include $(YAZINC)
+AM_CPPFLAGS = -I$(top_srcdir)/include $(YAZ_CFLAGS)
 
 zebralibs = ../../$(main_zebralib)
 
-LDADD = libtestlib.a $(zebralibs) $(YAZLALIB)
+LDADD = libtestlib.a $(zebralibs) $(YAZ_LIBS)
 
 clean-local:
 	-rm -rf *.LCK 

--- a/test/charmap/Makefile.am
+++ b/test/charmap/Makefile.am
@@ -7,9 +7,9 @@ EXTRA_DIST = zebra.cfg x.xml x.abs default.idx string.utf8.chr
 
 charmap1_SOURCES = charmap1.c
 
-AM_CPPFLAGS = -I$(top_srcdir)/include $(YAZINC)
+AM_CPPFLAGS = -I$(top_srcdir)/include $(YAZ_CFLAGS)
 
-LDADD = ../api/libtestlib.a ../../$(main_zebralib) $(YAZLALIB)
+LDADD = ../api/libtestlib.a ../../$(main_zebralib) $(YAZ_LIBS)
 
 clean-local:
 	-rm -rf *.LCK 

--- a/test/codec/Makefile.am
+++ b/test/codec/Makefile.am
@@ -5,6 +5,6 @@ TESTS = $(check_PROGRAMS)
 
 tstcodec_SOURCES = tstcodec.c
 
-AM_CPPFLAGS = -I$(top_srcdir)/include $(YAZINC)
+AM_CPPFLAGS = -I$(top_srcdir)/include $(YAZ_CFLAGS)
 
-LDADD = ../../$(main_zebralib) $(YAZLALIB)
+LDADD = ../../$(main_zebralib) $(YAZ_LIBS)

--- a/test/espec/Makefile.am
+++ b/test/espec/Makefile.am
@@ -7,9 +7,9 @@ EXTRA_DIST = zebra.cfg rec1.xml root.abs brief.est
 
 t1_SOURCES = t1.c
 
-AM_CPPFLAGS = -I$(top_srcdir)/include $(YAZINC)
+AM_CPPFLAGS = -I$(top_srcdir)/include $(YAZ_CFLAGS)
 
-LDADD = ../api/libtestlib.a ../../$(main_zebralib) $(YAZLALIB)
+LDADD = ../api/libtestlib.a ../../$(main_zebralib) $(YAZ_LIBS)
 
 clean-local:
 	-rm -rf *.LCK 

--- a/test/filters/Makefile.am
+++ b/test/filters/Makefile.am
@@ -11,9 +11,9 @@ grs_xml_SOURCES = grs.xml.c
 grs_xml_idzebra_SOURCES = grs.xml.idzebra.c
 grs_marc_SOURCES = grs.marc.c
 
-AM_CPPFLAGS = -I$(top_srcdir)/include $(YAZINC)
+AM_CPPFLAGS = -I$(top_srcdir)/include $(YAZ_CFLAGS)
 
-LDADD = ../api/libtestlib.a ../../$(main_zebralib) $(YAZLALIB)
+LDADD = ../api/libtestlib.a ../../$(main_zebralib) $(YAZ_LIBS)
 
 clean-local:
 	-rm -rf *.LCK 

--- a/test/marcxml/Makefile.am
+++ b/test/marcxml/Makefile.am
@@ -9,9 +9,9 @@ EXTRA_DIST = zebra.cfg record.abs m1.xml m2.xml m3.xml sample-marc
 t1_SOURCES = t1.c
 t2_SOURCES = t2.c
 
-AM_CPPFLAGS = -I$(top_srcdir)/include -I$(srcdir)/../api $(YAZINC)
+AM_CPPFLAGS = -I$(top_srcdir)/include -I$(srcdir)/../api $(YAZ_CFLAGS)
 
-LDADD = ../api/libtestlib.a ../../$(main_zebralib) $(YAZLALIB)
+LDADD = ../api/libtestlib.a ../../$(main_zebralib) $(YAZ_LIBS)
 
 clean-local:
 	-rm -rf *.LCK 

--- a/test/mbox/Makefile.am
+++ b/test/mbox/Makefile.am
@@ -7,9 +7,9 @@ EXTRA_DIST= zebra.cfg email2.flt $(mailboxfiles)
 
 mbox1_SOURCES = mbox1.c
 
-AM_CPPFLAGS = -I$(srcdir)/../api -I$(top_srcdir)/include $(YAZINC)
+AM_CPPFLAGS = -I$(srcdir)/../api -I$(top_srcdir)/include $(YAZ_CFLAGS)
 
-LDADD = ../api/libtestlib.a ../../$(main_zebralib) $(YAZLALIB)
+LDADD = ../api/libtestlib.a ../../$(main_zebralib) $(YAZ_LIBS)
 
 clean-local:
 	-rm -rf *.LCK 

--- a/test/rusmarc/Makefile.am
+++ b/test/rusmarc/Makefile.am
@@ -13,9 +13,9 @@ dist-hook:
 
 t1_SOURCES = t1.c
 
-AM_CPPFLAGS = -I$(top_srcdir)/include $(YAZINC)
+AM_CPPFLAGS = -I$(top_srcdir)/include $(YAZ_CFLAGS)
 
-LDADD = ../api/libtestlib.a ../../$(main_zebralib) $(YAZLALIB)
+LDADD = ../api/libtestlib.a ../../$(main_zebralib) $(YAZ_LIBS)
 
 clean-local:
 	-rm -rf *.LCK 

--- a/test/xpath/Makefile.am
+++ b/test/xpath/Makefile.am
@@ -13,9 +13,9 @@ xpath4_SOURCES = xpath4.c
 xpath5_SOURCES = xpath5.c
 xpath6_SOURCES = xpath6.c
 
-AM_CPPFLAGS = -I$(top_srcdir)/include $(YAZINC)
+AM_CPPFLAGS = -I$(top_srcdir)/include $(YAZ_CFLAGS)
 
-LDADD = ../api/libtestlib.a ../../$(main_zebralib) $(YAZLALIB)
+LDADD = ../api/libtestlib.a ../../$(main_zebralib) $(YAZ_LIBS)
 
 clean-local:
 	-rm -rf *.LCK 

--- a/test/xslt/Makefile.am
+++ b/test/xslt/Makefile.am
@@ -48,11 +48,11 @@ xslt4_SOURCES = xslt4.c
 xslt5_SOURCES = xslt5.c
 dom1_SOURCES = dom1.c
 
-AM_CPPFLAGS = -I$(srcdir)/../api -I$(top_srcdir)/include $(YAZINC)
+AM_CPPFLAGS = -I$(srcdir)/../api -I$(top_srcdir)/include $(YAZ_CFLAGS)
 
 zebralibs = ../../index/libidzebra-2.0.la 
 
-LDADD = ../api/libtestlib.a $(zebralibs) $(YAZLALIB)
+LDADD = ../api/libtestlib.a $(zebralibs) $(YAZ_LIBS)
 
 clean-local:
 	-rm -rf *.LCK 

--- a/util/Makefile.am
+++ b/util/Makefile.am
@@ -11,8 +11,8 @@ EXTRA_DIST = tstcharmap.chr emptycharmap.chr tstpass.txt tstres.cfg idzebra-abs2
 
 DISTCLEANFILES = idzebra-config-2.0
 
-AM_CPPFLAGS = -I$(srcdir)/../include $(YAZINC) -DDEFAULT_PROFILE_PATH=\"$(pkgdatadir)/tab\"
-LDADD = libidzebra-util.la $(YAZLALIB)
+AM_CPPFLAGS = -I$(srcdir)/../include $(YAZ_CFLAGS) -DDEFAULT_PROFILE_PATH=\"$(pkgdatadir)/tab\"
+LDADD = libidzebra-util.la $(YAZ_LIBS)
 
 libidzebra_util_la_SOURCES = version.c zint.c res.c charmap.c zebramap.c \
  passwddb.c zebra-lock.c dirent.c xpath.c atoi_zn.c snippet.c flock.c \


### PR DESCRIPTION
This patch is further preparation to add support for detecting yaz, yaz-server and yaz-icu via pkg-config. It allows us to use the output of pkg-config's variables directly.

These variables use YAZ_CFLAGS/LIBS format.