### PR TITLE
Clean up left-over test files

### DIFF
--- a/test/gils/Makefile.am
+++ b/test/gils/Makefile.am
@@ -15,5 +15,7 @@ clean-local:
 	-rm -rf *.LCK 
 	-rm -rf *.log 
 	-rm -rf *.mf 
+	-rm -rf out
+	-rm -rf socket
 	-rm -rf reg/*.mf 
 

--- a/test/zsh/Makefile.am
+++ b/test/zsh/Makefile.am
@@ -14,6 +14,7 @@ clean-local:
 	-rm -rf *.LCK 
 	-rm -rf *.log 
 	-rm -rf *.mf 
+	-rm -rf test*.zsh.out
 	-rm -rf reg/*.LCK 
 	-rm -rf reg/*.log 
 	-rm -rf reg/*.mf 


### PR DESCRIPTION
This patchset adds patches to clean up some left-over test files.

I've left the trailing whitespaces in, as they are on most lines in these files.