### PR TITLE
Convert files encoded in ISO-8859-1 to UTF-8

### DIFF
--- a/tab/dan1.att
+++ b/tab/dan1.att
@@ -3,20 +3,20 @@ reference 1.2.840.10003.3.15
 att 1         Classification-DK5-alfa-subdivision   # au Alfabetisk underdeling DK-5
 att 2         Subject-controlled                    # ke Kontrollerede emneord
 att 3         Subject-DBC                           # db DBC emneord
-att 4         Subject-DBC-non-fiction               # df DBC-faglitterære emneord
-att 5         Subject-DBC-fiction                   # ds DBC-skønlitterære emneord
+att 4         Subject-DBC-non-fiction               # df DBC-faglitterÃ¦re emneord
+att 5         Subject-DBC-fiction                   # ds DBC-skÃ¸nlitterÃ¦re emneord
 att 6         Subject-DBC-music                     # me DBC-Musikemneord
 att 7         Form-as-subject                       # fm Form betegnelse som emneord 
 att 8         Level-as-subject                      # nb Niveau-emneord
 att 9         Shelf-mark                            # po Opstillingselement
 att 10        Classification-DK5-number             # dk DK5
 att 11        Classification-as-shelf-mark          # ok Klassifikation som opstilling
-att 12        Obsolete-shelf-mark                   # gd Forældet dk-klassemærke
+att 12        Obsolete-shelf-mark                   # gd ForÃ¦ldet dk-klassemÃ¦rke
 att 13        Subject-FUI                           # fg FUI-Koder
 att 14        Catalogue-code                        # kk Katalogkode
 att 15        LIX-number                            # ix LIX
 att 16        Music-notation                        # nm Musikalsk notation
 att 17        Item-number                           # nr Numre
-att 18        Local-item-number                     # en Numre på ens materiale
+att 18        Local-item-number                     # en Numre pÃ¥ ens materiale
 att 19        Previous-FAUST-code                   # tf Tidligere og lokale faustnumre 
-att 20        Title-host-publication                # lvx Værtspublikationstitel (uden nummer)
+att 20        Title-host-publication                # lvx VÃ¦rtspublikationstitel (uden nummer)

--- a/tab/danmarc.abs
+++ b/tab/danmarc.abs
@@ -13,30 +13,30 @@ elm 10/?        DanBib-ID-nummer                    Item-number
 elm 10/?/a      DanBib-ID-nummer                    Item-number
 elm 10/?/b      Dataproducentens-biblioteksnummer   -
 
-elm 11          ID-nummer-på-hovedmaterialets-post  -
-elm 11/?        ID-nummer-på-hovedmaterialets-post  -
-elm 11/?/a      ID-nummer-på-hovedmaterialets-post  -
+elm 11          ID-nummer-pÃ¥-hovedmaterialets-post  -
+elm 11/?        ID-nummer-pÃ¥-hovedmaterialets-post  -
+elm 11/?/a      ID-nummer-pÃ¥-hovedmaterialets-post  -
 
-elm 14          ID-nummer-på-post-på-højere-niveau  -
-elm 14/?        ID-nummer-på-post-på-højere-niveau  -
-elm 14/?/a      ID-nummer-på-post-på-højere-niveau  -
-elm 14/?/x      ID-nummer-på-post-på-højere-niveau  Item-number
+elm 14          ID-nummer-pÃ¥-post-pÃ¥-hÃ¸jere-niveau  -
+elm 14/?        ID-nummer-pÃ¥-post-pÃ¥-hÃ¸jere-niveau  -
+elm 14/?/a      ID-nummer-pÃ¥-post-pÃ¥-hÃ¸jere-niveau  -
+elm 14/?/x      ID-nummer-pÃ¥-post-pÃ¥-hÃ¸jere-niveau  Item-number
 
-elm 15          ID-nummer-på-post-på-lavere-niveau  -
-elm 15/?        ID-nummer-på-post-på-lavere-niveau  Item-number
-elm 15/?/a      ID-nummer-på-post-på-lavere-niveau  Item-number
+elm 15          ID-nummer-pÃ¥-post-pÃ¥-lavere-niveau  -
+elm 15/?        ID-nummer-pÃ¥-post-pÃ¥-lavere-niveau  Item-number
+elm 15/?/a      ID-nummer-pÃ¥-post-pÃ¥-lavere-niveau  Item-number
 
-elm 16          ID-nummer-på-værtspublikation       -
-elm 16/?        ID-nummer-på-værtspublikation       -
-elm 16/?/a      ID-nummer-på-værtspublikation       -
+elm 16          ID-nummer-pÃ¥-vÃ¦rtspublikation       -
+elm 16/?        ID-nummer-pÃ¥-vÃ¦rtspublikation       -
+elm 16/?/a      ID-nummer-pÃ¥-vÃ¦rtspublikation       -
 
-elm 17          ID-nummer-på-første-udgave          -
-elm 17/?        ID-nummer-på-første-udgave          Item-number,Local-item-number
-elm 17/?/a      ID-nummer-på-første-udgave          Item-number,Local-item-number
+elm 17          ID-nummer-pÃ¥-fÃ¸rste-udgave          -
+elm 17/?        ID-nummer-pÃ¥-fÃ¸rste-udgave          Item-number,Local-item-number
+elm 17/?/a      ID-nummer-pÃ¥-fÃ¸rste-udgave          Item-number,Local-item-number
 
-elm 18          ID-nummer-på-anden-post-for-samme-materiale          -
-elm 18/?        ID-nummer-på-anden-post-for-samme-materiale          Item-number,Local-item-number
-elm 18/?/a      ID-nummer-på-anden-post-for-samme-materiale          Item-number,Local-item-number
+elm 18          ID-nummer-pÃ¥-anden-post-for-samme-materiale          -
+elm 18/?        ID-nummer-pÃ¥-anden-post-for-samme-materiale          Item-number,Local-item-number
+elm 18/?/a      ID-nummer-pÃ¥-anden-post-for-samme-materiale          Item-number,Local-item-number
 
 elm 20          Nationalbibliografisk-nummer        -
 elm 20/?        Nationalbibliografisk-nummer        Item-number
@@ -46,26 +46,26 @@ elm 20/?/b      Nationalbibliografisk-nummer        Item-number
 elm 21          ISBN                                -
 elm 21/?        ISBN                                ISBN,Identifier-standard,Item-number
 elm 21/?/a      ISBN                                ISBN,Identifier-standard,Item-number
-elm 21/?/b      Tilføjelse                          -
+elm 21/?/b      TilfÃ¸jelse                          -
 elm 21/?/c      Bindtype                            -
-elm 21/?/d      Anskaffelsesvilkår/pris             -
+elm 21/?/d      AnskaffelsesvilkÃ¥r/pris             -
 elm 21/?/n      Bestillingsnummer                   Item-number
 elm 21/?/x      Fejltryk-eller-fejlagtigt-anvendt-ISBN  ISBN,Identifier-standard,Item-number
 
 elm 22          ISSN                                -
 elm 22/?        ISSN                                ISBN,Identifier-standard,Item-number
 elm 22/?/a      ISSN                                ISBN,Identifier-standard,Item-number
-elm 22/?/b      Tilføjelse                          -
+elm 22/?/b      TilfÃ¸jelse                          -
 elm 22/?/c      Bindtype                            -
-elm 22/?/d      Anskaffelsesvilkår/pris             -
+elm 22/?/d      AnskaffelsesvilkÃ¥r/pris             -
 elm 22/?/z      Fejlagtigt-tildelt-ISSN             ISBN,Identifier-standard,Item-number
 
 elm 28          ISMN                                -
 elm 28/?        ISMN                                ISBN,Identifier-standard,Item-number
 elm 28/?/a      ISMN                                ISBN,Identifier-standard,Item-number
-elm 28/?/b      Tilføjelse                          -
+elm 28/?/b      TilfÃ¸jelse                          -
 elm 28/?/c      Bindtype                            -
-elm 28/?/d      Anskaffelsesvilkår/pris             -
+elm 28/?/d      AnskaffelsesvilkÃ¥r/pris             -
 elm 28/?/n      Bestillingsnummer                   Item-number
 
 elm 30          CODEN                               -
@@ -79,16 +79,16 @@ elm 32/?/x      Kode-for-fagbibliografi             Catalogue-code
 
 #elm 34          Kodede-matematiske-oplysninger      -
 #elm 34/?        Kodede-matematiske-oplysninger      Code-map-scale
-#elm 34/?/a      Målestokstype                       Code-map-scale
-#elm 34/?/b      Konstant-lineær-vandret-målestok    Code-map-scale
+#elm 34/?/a      MÃ¥lestokstype                       Code-map-scale
+#elm 34/?/b      Konstant-lineÃ¦r-vandret-mÃ¥lestok    Code-map-scale
 #elm 34/?/d      Koordinater                         Code-map-scale
 #elm 34/?/e      Koordinater                         Code-map-scale
 #elm 34/?/f      Koordinater                         Code-map-scale
 #elm 34/?/g      Koordinater                         Code-map-scale
 
-elm 38          Opstillingskode-for-børnelitteratur -
-elm 38/?        Opstillingskode-for-børnelitteratur -
-elm 38/?/a      Opstillingskode-for-børnelitteratur -
+elm 38          Opstillingskode-for-bÃ¸rnelitteratur -
+elm 38/?        Opstillingskode-for-bÃ¸rnelitteratur -
+elm 38/?/a      Opstillingskode-for-bÃ¸rnelitteratur -
 
 elm 39          Opstillingskode-for-musikoptagelser -
 elm 39/?        Opstillingskode-for-musikoptagelser -
@@ -99,7 +99,7 @@ elm 41/?        Sprogkode                           -
 elm 41/?/a      Materialets-sprog                   Code-language
 #elm 41/?/b      Mellemoriginalens-sprog             Code-language-original
 #elm 41/?/c      Originaludgavens-sprog              Code-language-original
-elm 41/?/d      Sprog-i-resuméer                    Code-language
+elm 41/?/d      Sprog-i-resumÃ©er                    Code-language
 elm 41/?/e      Sprog-i-mindre-dele-af-materialet   Code-language
 elm 41/?/p      Sprog-i-parallel-tekst              Code-language
 elm 41/?/u      Sprog-i-undertekster-til-film/video Code-language
@@ -109,12 +109,12 @@ elm 42/?        Lix-tal                             -
 elm 42/?/a      Samlet-lix-tal                      LIX-number
 elm 42/?/b      Specifikation-af-lix-tal            -
 
-elm 43          Kode-for-geografisk-område          -
-elm 43/?        Kode-for-geografisk-område          -
-elm 43/?/a      Kode-for-geografisk-område          -
+elm 43          Kode-for-geografisk-omrÃ¥de          -
+elm 43/?        Kode-for-geografisk-omrÃ¥de          -
+elm 43/?/a      Kode-for-geografisk-omrÃ¥de          -
 
-elm 44          Pædagogisk-fagkode                  -
-elm 44/?        Pædagogisk-fagkode                  Subject-FUI
+elm 44          PÃ¦dagogisk-fagkode                  -
+elm 44/?        PÃ¦dagogisk-fagkode                  Subject-FUI
 elm 44/?/a      Kode-for-skoleretning               Subject-FUI
 elm 44/?/b      Kode-for-fag-og-undervisningsmateriale  Subject-FUI
 
@@ -198,8 +198,8 @@ elm 96/?/z      Lokaliseringskode                   -
 elm 100         Personnavn                  -
 elm 100/?       Personnavn                  Personal-name:w,Personal-name:p,Shelf-mark
 #elm 100/?/a     Efternavn/fornavn-alene     Personal-name:w,Personal-name:p,Personal-name-personal:w,Personal-name-personal:p,Shelf-mark
-#elm 100/?/c     Fødselsår                   Personal-name:w,Personal-name:p,Personal-name-personal:w,Personal-name-personal:p,Shelf-mark
-#elm 100/?/f     Tilføjelse                  Personal-name:w,Personal-name:p,Personal-name-personal:w,Personal-name-personal:p,Shelf-mark
+#elm 100/?/c     FÃ¸dselsÃ¥r                   Personal-name:w,Personal-name:p,Personal-name-personal:w,Personal-name-personal:p,Shelf-mark
+#elm 100/?/f     TilfÃ¸jelse                  Personal-name:w,Personal-name:p,Personal-name-personal:w,Personal-name-personal:p,Shelf-mark
 #elm 100/?/h     Fornavn                     Personal-name:w,Personal-name:p,Personal-name-personal:w,Personal-name-personal:p,Shelf-mark
 #elm 100/?/k     Fuldt-udskrevet-fornavn     Personal-name:w,Personal-name:p,Personal-name-personal:w,Personal-name-personal:p,Shelf-mark
 
@@ -207,36 +207,36 @@ elm 110         Korporationsnavn-opstillingselement     -
 elm 110/?       Korporationsnavn-opstillingselement     Personal-name:w,Personal-name:p,Corporate-name:w,Corporate-name:p,Shelf-mark
 #elm 110/?/a     Korporationsnavn                        Personal-name:w,Personal-name:p,Personal-name-corporate:w,Personal-name-corporate:p,Shelf-mark
 #elm 110/?/c     Underkorporation                        Personal-name:w,Personal-name:p,Personal-name-corporate:w,Personal-name-corporate:p,Shelf-mark
-#elm 110/?/e     Tilføjelse                              Personal-name:w,Personal-name:p,Personal-name-corporate:w,Personal-name-corporate:p,Shelf-mark
-#elm 110/?/i     Nummer-på-konference                    Personal-name:w,Personal-name:p,Personal-name-corporate:w,Personal-name-corporate:p,Shelf-mark
+#elm 110/?/e     TilfÃ¸jelse                              Personal-name:w,Personal-name:p,Personal-name-corporate:w,Personal-name-corporate:p,Shelf-mark
+#elm 110/?/i     Nummer-pÃ¥-konference                    Personal-name:w,Personal-name:p,Personal-name-corporate:w,Personal-name-corporate:p,Shelf-mark
 #elm 110/?/j     Sted-for-konference                     Personal-name:w,Personal-name:p,Personal-name-corporate:w,Personal-name-corporate:p,Shelf-mark
-#elm 110/?/k     År-for-konference                       Personal-name:w,Personal-name:p,Personal-name-corporate:w,Personal-name-corporate:p,Shelf-mark
+#elm 110/?/k     Ã…r-for-konference                       Personal-name:w,Personal-name:p,Personal-name-corporate:w,Personal-name-corporate:p,Shelf-mark
 
-elm 210         Forkortet-nøgletitel                    -
-elm 210/?       Forkortet-nøgletitel                    Title-key,Title,Title:p
-elm 210/?/a     Forkortet-nøgletitel                    Title-key,Title,Title:p
-elm 210/?/b     Forkortet-identificerende-tilføjelse    Title-key,Title,Title:p
+elm 210         Forkortet-nÃ¸gletitel                    -
+elm 210/?       Forkortet-nÃ¸gletitel                    Title-key,Title,Title:p
+elm 210/?/a     Forkortet-nÃ¸gletitel                    Title-key,Title,Title:p
+elm 210/?/b     Forkortet-identificerende-tilfÃ¸jelse    Title-key,Title,Title:p
 
-elm 222         Nøgletitel                  -
-elm 222/?       Nøgletitel                  Title-key,Title,Title:p
-elm 222/?/a     Nøgletitel                  Title-key,Title,Title:p
-elm 222/?/b     Identificerende-tilføjelse  Title-key,Title,Title:p
+elm 222         NÃ¸gletitel                  -
+elm 222/?       NÃ¸gletitel                  Title-key,Title,Title:p
+elm 222/?/a     NÃ¸gletitel                  Title-key,Title,Title:p
+elm 222/?/b     Identificerende-tilfÃ¸jelse  Title-key,Title,Title:p
 
 elm 239         Uniform-titel/standardtitel-opstillingselement  -
 elm 239/?       Uniform-titel/standardtitel-opstillingselement  Title-uniform,Title,Title:p
 elm 239/?/t     Uniform-titel                                   Title-uniform,Title,Title:p
 elm 239/?/u     Almindeligt-kendt-tilnavn                       Title-uniform,Title,Title:p
 elm 239/?/v     Uddragstitel                                    Title-uniform,Title,Title:p
-elm 239/?/Ø     Uniform-titel/standardtitel-opstillingselement  -
-elm 239/?/ø     Identificerende-tilføjelser                     Title-uniform,Title
+elm 239/?/Ã˜     Uniform-titel/standardtitel-opstillingselement  -
+elm 239/?/Ã¸     Identificerende-tilfÃ¸jelser                     Title-uniform,Title
 
 elm 240         Uniform-titel-opstillingselement    -
 elm 240/?       Uniform-titel-opstillingselement    Title-uniform,Title,Title:p
 elm 240/?/a     Uniform-titel                       Title-uniform,Title,Title:p
 elm 240/?/j     Andet-identificerende-element       Title-uniform,Title,Title:p
-elm 240/?/r     Sprog-i-oversættelse/version        -
-elm 240/?/u     Udgivelsesår                        -
-elm 240/?/ø     Identificerende-tilføjelser         Title-uniform,Title
+elm 240/?/r     Sprog-i-oversÃ¦ttelse/version        -
+elm 240/?/u     UdgivelsesÃ¥r                        -
+elm 240/?/Ã¸     Identificerende-tilfÃ¸jelser         Title-uniform,Title
 
 elm 241         Originaltitel           -
 elm 241/?       Originaltitel           Title,Title:p
@@ -253,17 +253,17 @@ elm 245/?/c     Undertitel-og-anden-titelinformation        Title,Title:p
 elm 245/?/e     Ophavsangivelser-opslag                     -
 elm 245/?/f     Ophavsangivelser                            -
 elm 245/?/g     Numerisk-eller-alfabetisk-betegnelse-for-bind                       Title,Title:p
-elm 245/?/i     Anden-primær/sekundær-ophavsangivelse-kun-i-nationalbibliogafien    -
-elm 245/?/j     Anden-primær/sekundær-ophavsangivelse-ikke-i-nationalbibliogafien   -
-elm 245/?/o     Titel-på-supplement/sektion                  -
+elm 245/?/i     Anden-primÃ¦r/sekundÃ¦r-ophavsangivelse-kun-i-nationalbibliogafien    -
+elm 245/?/j     Anden-primÃ¦r/sekundÃ¦r-ophavsangivelse-ikke-i-nationalbibliogafien   -
+elm 245/?/o     Titel-pÃ¥-supplement/sektion                  -
 elm 245/?/p     Paralleltitel                               Title-parallel,Title,Title:p
 elm 245/?/s     Parallel-undertitel                         Title-parallel,Title,Title:p
 elm 245/?/u     Markant-undertitel                          Title,Title:p
-elm 245/?/x     Hovedtitel-på-tilføjet-værk-af-andet-ophav  Title,Title:p
-elm 245/?/y     Titel-på-supplement                         Title,Title:p
-elm 245/?/Ø     Originaltitel-og-ophavsangivelse            -
-elm 245/?/æ     Identificerende-ophavsangivelse-til-titel   -
-elm 245/?/ø     Identificerende-tilføjelser-til-titel       -
+elm 245/?/x     Hovedtitel-pÃ¥-tilfÃ¸jet-vÃ¦rk-af-andet-ophav  Title,Title:p
+elm 245/?/y     Titel-pÃ¥-supplement                         Title,Title:p
+elm 245/?/Ã˜     Originaltitel-og-ophavsangivelse            -
+elm 245/?/Ã¦     Identificerende-ophavsangivelse-til-titel   -
+elm 245/?/Ã¸     Identificerende-tilfÃ¸jelser-til-titel       -
 
 elm 248         Bindspecifikation                       -
 elm 248/?       Bindspecifikation                       Title
@@ -271,7 +271,7 @@ elm 248/?/a     Bindtitel/supplementstitel              Title,Title:p
 elm 248/?/c     Undertitel-og-anden-titelinformation    Title,Title:p
 elm 248/?/e     Ophavsangivelse                         -
 elm 248/?/g     Bindnummer/supplementsbetegnelse        Title
-elm 248/?/j     Udgivelsesår                            -
+elm 248/?/j     UdgivelsesÃ¥r                            -
 elm 248/?/l     Generel-note                            Note
 elm 248/?/w     Udgavebetegnelse                        -
 
@@ -289,27 +289,27 @@ elm 255/?/a     Nummereringer-og-dateringer   -
 
 elm 256         Matematiske-oplysninger-for-kartografiske-materialer    -
 #elm 256/?       Matematiske-oplysninger-for-kartografiske-materialer    Code-map-scale
-#elm 256/?/a     Målestok                                                Code-map-scale
+#elm 256/?/a     MÃ¥lestok                                                Code-map-scale
 #elm 256/?/c     Projektion                                              Code-map-scale
 
 elm 260         Publicering/distribution        -
 elm 260/?       Publicering/distribution        -
 elm 260/?/a     Hjemsted-for-forlag             Place-publication
-elm 260/?/b     Navn-på-forlag                  Publisher
-elm 260/?/c     Udgivelsesår                    Date-of-Publication
-elm 260/?/d     Adresse-på-forlag               -
-elm 260/?/e     Funktionsangivelse-på-forlag    -
-elm 260/?/f     Hjemsted-for-distributør        Place-publication
-elm 260/?/g     Navn-på-distributør             -
+elm 260/?/b     Navn-pÃ¥-forlag                  Publisher
+elm 260/?/c     UdgivelsesÃ¥r                    Date-of-Publication
+elm 260/?/d     Adresse-pÃ¥-forlag               -
+elm 260/?/e     Funktionsangivelse-pÃ¥-forlag    -
+elm 260/?/f     Hjemsted-for-distributÃ¸r        Place-publication
+elm 260/?/g     Navn-pÃ¥-distributÃ¸r             -
 elm 260/?/k     Trykkerioplysninger             -
-elm 260/?/p     Navn-på-forlag/distributør-på-andet-sprog/alfabet   publisher
+elm 260/?/p     Navn-pÃ¥-forlag/distributÃ¸r-pÃ¥-andet-sprog/alfabet   publisher
 
 elm 300         Fysisk-beskrivelse                          -
 elm 300/?       Fysisk-beskrivelse                          -
 elm 300/?/D     Fysisk-beskrivelse                          -
 elm 300/?/a     Omfang-uden-specifik-materialebetegnelse    -
 elm 300/?/b     Yderligere-fysisk-beskrivelse               -
-elm 300/?/c     Størrelse                                   -
+elm 300/?/c     StÃ¸rrelse                                   -
 elm 300/?/d     Bilag                                       -
 elm 300/?/e     Tekniske-oplysninger                        -
 elm 300/?/l     Spilletid                                   -
@@ -323,26 +323,26 @@ elm 440/?/a     Seriens-hovedtitel                                  Title,Title-
 elm 440/?/c     Undertitel-eller-anden-titelinformation             Title,Title-series,Title:p
 elm 440/?/e     Ophavsangivelse                                     -
 elm 440/?/n     Numerisk/alfabetisk-betegnelse-for-sektion          Title,Title-series
-elm 440/?/o     Titel-på-sektion                                    Title,Title-series,Title:p
+elm 440/?/o     Titel-pÃ¥-sektion                                    Title,Title-series,Title:p
 elm 440/?/p     Seriens-paralleltitel                               Title,Title-series,Title:p
 elm 440/?/v     Nummerering-og-datering-i-serien                    Title,Title-series
 elm 440/?/y     Seriebetegnelse-i-materialets-form                  -
 elm 440/?/z     Seriens-ISSN                                        ISSN
-elm 440/?/å     Seriebetegnelse-i-materialets-form                  -
-elm 440/?/æ     Identificerende-ophavsangivelse-til-seriens-titel   -
-elm 440/?/ø     Identificerende-tilføjelse-til-seriens-titel        Title,Title-series,Title:p
+elm 440/?/Ã¥     Seriebetegnelse-i-materialets-form                  -
+elm 440/?/Ã¦     Identificerende-ophavsangivelse-til-seriens-titel   -
+elm 440/?/Ã¸     Identificerende-tilfÃ¸jelse-til-seriens-titel        Title,Title-series,Title:p
 
 elm 500         Periodicums-frekvens    -
 elm 500/?       Periodicums-frekvens    -
 elm 500/?/a     Periodicums-frekvens    -
 
-elm 501         Systemkrav/adgangsmåde  -
+elm 501         Systemkrav/adgangsmÃ¥de  -
 elm 501/?       Systemkrav              Note
-elm 501/?/a     Adgangsmåde             Note
+elm 501/?/a     AdgangsmÃ¥de             Note
 
-elm 502         Originaltitel/oversættelse  -
-elm 502/?       Originaltitel/oversættelse  Note
-elm 502/?/a     Originaltitel/oversættelse  Note
+elm 502         Originaltitel/oversÃ¦ttelse  -
+elm 502/?       Originaltitel/oversÃ¦ttelse  Note
+elm 502/?/a     Originaltitel/oversÃ¦ttelse  Note
 
 elm 504         Indholdsbeskrivelse     -
 elm 504/?       Indholdsbeskrivelse     Note
@@ -365,9 +365,9 @@ elm 508         Sprog-og-alfabet        -
 elm 508/?       Sprog-og-alfabet        Note
 elm 508/?/a     Sprog-og-alfabet        Note
 
-elm 509         Besætning               -
-elm 509/?       Besætning               Note
-elm 509/?/a     Besætning               Note
+elm 509         BesÃ¦tning               -
+elm 509/?       BesÃ¦tning               Note
+elm 509/?/a     BesÃ¦tning               Note
 
 elm 512         Beskrivelse                     -
 elm 512/?       Beskrivelse                     -
@@ -377,17 +377,17 @@ elm 512/?/e     Ophavsangivelse                 -
 elm 512/?/i     Indledende-tekst                -
 elm 512/?/t     Titel                           Title,Title:p
 
-elm 513         Fælles-ophavsangivelse  -
-elm 513/?       Fælles-ophavsangivelse  -
-elm 513/?/e     Primær-ophavsangivelse  -
+elm 513         FÃ¦lles-ophavsangivelse  -
+elm 513/?       FÃ¦lles-ophavsangivelse  -
+elm 513/?/e     PrimÃ¦r-ophavsangivelse  -
 
-elm 517         Målgruppe-og-anvendelighed  -
-elm 517/?       Målgruppe-og-anvendelighed  Note
-elm 517/?/a     Målgruppe-og-anvendelighed  Note
+elm 517         MÃ¥lgruppe-og-anvendelighed  -
+elm 517/?       MÃ¥lgruppe-og-anvendelighed  Note
+elm 517/?/a     MÃ¥lgruppe-og-anvendelighed  Note
 
-elm 520         Værkets-bibliografiske-historie -
-elm 520/?       Værkets-bibliografiske-historie -
-elm 520/?/a     Værkets-bibliografiske-historie -
+elm 520         VÃ¦rkets-bibliografiske-historie -
+elm 520/?       VÃ¦rkets-bibliografiske-historie -
+elm 520/?/a     VÃ¦rkets-bibliografiske-historie -
 elm 520/?/b     Supplerende-tekst               -
 elm 520/?/i     Indledende-tekst                -
 elm 520/?/t     Titel                           Title,Title:p
@@ -396,11 +396,11 @@ elm 521         Udgavens-oplag          -
 elm 521/?       Udgavens-oplag          -
 elm 521/?/a     Oplagsbetegnelse        -
 elm 521/?/b     Seneste-oplag           -
-elm 521/?/c     Oplagets-udgivelsesår   Date-of-publication
+elm 521/?/c     Oplagets-udgivelsesÃ¥r   Date-of-publication
 
-elm 526         Sammenhæng-med-andre-værker -
-elm 526/?       Sammenhæng-med-andre-værker -
-elm 526/?/a     Sammenhæng-med-andre-værker Note
+elm 526         SammenhÃ¦ng-med-andre-vÃ¦rker -
+elm 526/?       SammenhÃ¦ng-med-andre-vÃ¦rker -
+elm 526/?/a     SammenhÃ¦ng-med-andre-vÃ¦rker Note
 elm 526/?/b     Supplerende-tekst           -
 elm 526/?/d     Ophavsangivelse-foran-titel -
 elm 526/?/e     Ophavsangivelse             -
@@ -425,8 +425,8 @@ elm 534         Partielt-indhold        -
 elm 534/?       Partielt-indhold        Note
 elm 534/?/a     Partielt-indhold        Note
 
-elm 538         Numre-der-indgår-i-materialet   -
-elm 538/?       Numre-der-indgår-i-materialet   Item-number
+elm 538         Numre-der-indgÃ¥r-i-materialet   -
+elm 538/?       Numre-der-indgÃ¥r-i-materialet   Item-number
 elm 538/?/a     Nummer                          Item-number
 elm 538/?/b     Editionsnummer                  Item-number
 elm 538/?/c     Pladenummer                     Item-number
@@ -438,11 +438,11 @@ elm 539         Grundlaget-for-katalogiseringen -
 elm 539/?       Grundlaget-for-katalogiseringen -
 elm 539/?/a     Grundlaget-for-katalogiseringen -
 
-elm 557         Periodicum-som-værtspublikation-for-I-analyse   -
-elm 557/?       Periodicum-som-værtspublikation-for-I-analyse   -
-elm 557/?/V     Periodicum-som-værtspublikation-for-I-analyse   -
+elm 557         Periodicum-som-vÃ¦rtspublikation-for-I-analyse   -
+elm 557/?       Periodicum-som-vÃ¦rtspublikation-for-I-analyse   -
+elm 557/?/V     Periodicum-som-vÃ¦rtspublikation-for-I-analyse   -
 elm 557/?/a     Titel                                           - # Title,Title-host-item,Title:p
-elm 557/?/j     Udgivelsesår                                    -
+elm 557/?/j     UdgivelsesÃ¥r                                    -
 elm 557/?/v     Nummerering/datering                            - # Title,Title-host-item,Title:p
 
 elm 559         Generel-note            -
@@ -452,19 +452,19 @@ elm 559/?/a     Generel-note            Note
 elm 600         Personnavn-emneord      -
 #elm 600/?       Personnavn-emneord      Subject-controlled,Subject-name-personal,Subject:p
 #elm 600/?/a     Efternavn/fornavn-alene Subject-controlled,Subject-name-personal,Subject:p
-#elm 600/?/c     Fødselsår               Subject-controlled,Subject-name-personal,Subject:p
+#elm 600/?/c     FÃ¸dselsÃ¥r               Subject-controlled,Subject-name-personal,Subject:p
 #elm 600/?/e     Romertal                Subject-controlled,Subject-name-personal,Subject:p
-#elm 600/?/f     Tilføjelse              Subject-controlled,Subject-name-personal,Subject:p
+#elm 600/?/f     TilfÃ¸jelse              Subject-controlled,Subject-name-personal,Subject:p
 #elm 600/?/h     Fornavn                 Subject-controlled,Subject-name-personal,Subject:p
 #elm 600/?/k     Fuldt-udskrevet-fornavn Subject-controlled,Subject-name-personal,Subject:p
 #elm 600/?/x     Underdeling-emne/art    Subject-controlled,Subject-name-personal,Subject:p
-#elm 600/?/å     Personnavn-emneord      Subject-controlled,Subject-name-personal,Subject:p
+#elm 600/?/Ã¥     Personnavn-emneord      Subject-controlled,Subject-name-personal,Subject:p
 
 elm 610         Korporationsnavn-emneord    -
 #elm 610/?       Korporationsnavn-emneord    Subject-controlled,Subject-name-corporate,Subject:p
 #elm 610/?/a     Korporationsnavn            Subject-controlled,Subject-name-corporate,Subject:p
 #elm 610/?/c     Underkorporation            Subject-controlled,Subject-name-corporate,Subject:p
-#elm 610/?/e     Tilføjelse                  Subject-controlled,Subject-name-corporate,Subject:p
+#elm 610/?/e     TilfÃ¸jelse                  Subject-controlled,Subject-name-corporate,Subject:p
 #elm 610/?/t     Titel                       Subject-controlled,Subject-name-corporate,Subject:p
 #elm 610/?/x     Underdeling-emne/art        Subject-controlled,Subject-name-corporate,Subject:p
 #elm 610/?/y     Underdeling-periode         Subject-controlled,Subject-name-corporate,Subject:p
@@ -484,7 +484,7 @@ elm 630         Kontrolleret-emneord    -
 #elm 631/?       Ukontrolleret-emneord   Subject-controlled,Subject-uncontrolled,Subject:p,Subject-uncontrolled:p
 #elm 631/?/a     Ukontrolleret-emneord   Subject-controlled,Subject-uncontrolled,Subject:p,Subject-uncontrolled:p
 #elm 631/?/b     Andre-bibliotekers-ukontrollerede-emneord   Subject-controlled,Subject-uncontrolled,Subject:p,Subject-uncontrolled:p
-#elm 631/?/f     Ukontrolleret-faglitterært-emneord          Subject-controlled,Subject-uncontrolled,Subject:p,Subject-uncontrolled:p
+#elm 631/?/f     Ukontrolleret-faglitterÃ¦rt-emneord          Subject-controlled,Subject-uncontrolled,Subject:p,Subject-uncontrolled:p
 #
 elm 633         Stednavn                -
 #elm 633/?       Stednavn                Subject-controlled,Subject-controlled,Subject:p,Subject-controlled:p
@@ -508,25 +508,25 @@ elm 651         LC-geografisk-emneord   subject-controlled
 #elm 651/?/x     Underdeling-emne/art    Subject
 #elm 651/?/z     Underdeling-lokalitet   Subject
 
-elm 652         DK5-klassemærke         -
-elm 652/?       DK5-klassemærke         -
+elm 652         DK5-klassemÃ¦rke         -
+elm 652/?       DK5-klassemÃ¦rke         -
 elm 652/?/a     Efternavn/navn/korporationsnavn-som-alfabetisk-underdeling  Classification-DK5-alfa-subdivision
 elm 652/?/b     Andet-som-alfabetisk-underdeling                    Classification-DK5-alfa-subdivision,Subject-controlled
-elm 652/?/c     Fødselsår                                           Classification-DK5-alfa-subdivision
+elm 652/?/c     FÃ¸dselsÃ¥r                                           Classification-DK5-alfa-subdivision
 elm 652/?/h     Fornavn                                             Classification-DK5-alfa-subdivision,Subject-controlled
-elm 652/?/i     Analytisk-klassemærke                               Classification-DK5-number
+elm 652/?/i     Analytisk-klassemÃ¦rke                               Classification-DK5-number
 elm 652/?/m     Opstillings-og-hovedplacering                       Classification-DK5-number,Classification-as-shelf-mark
 elm 652/?/n     Nationalbibliografisk-hovedplacering                Classification-DK5-number
-elm 652/?/o     Opstillingsklassemærkeog-bibliotekshovedplacering   Classification-DK5-number
+elm 652/?/o     OpstillingsklassemÃ¦rkeog-bibliotekshovedplacering   Classification-DK5-number
 elm 652/?/p     Biplacering                                         Classification-DK5-number
 elm 652/?/q     Nationalbibliografisk-biplacering                   Classification-DK5-number
 elm 652/?/r     Biblioteksbiplacering                               Classification-DK5-number
-elm 652/?/v     Tilføjede-cifre-efter-kolon                         -
-elm 652/?/z     Tilføjede-cifre-efter-bindestreg                    -
-elm 652/?/å     Feltnumerator                                       -
+elm 652/?/v     TilfÃ¸jede-cifre-efter-kolon                         -
+elm 652/?/z     TilfÃ¸jede-cifre-efter-bindestreg                    -
+elm 652/?/Ã¥     Feltnumerator                                       -
 
-elm 654         Forældet-DK5-klassemærke    -
-#elm 654/?       Forældet-DK5-klassemærke    Classification
+elm 654         ForÃ¦ldet-DK5-klassemÃ¦rke    -
+#elm 654/?       ForÃ¦ldet-DK5-klassemÃ¦rke    Classification
 #elm 654/?/p     Biplacering                 Classification
 
 elm 660         MeSH-emneord            -
@@ -534,8 +534,8 @@ elm 660/?       MeSH-emneord            Subject-controlled,Subject-controlled,ME
 elm 660/?/a     MeSH-emneord            Subject-controlled,Subject-controlled,MESH-Subject
 elm 660/?/x     Generel-underdeling     Subject-controlled,Subject-controlled,MESH-Subject
 
-elm 661         Europæisk-pædagogisk-tesaurus   -
-elm 661/?       Europæisk-pædagogisk-tesaurus   Subject-controlled,Subject-controlled
+elm 661         EuropÃ¦isk-pÃ¦dagogisk-tesaurus   -
+elm 661/?       EuropÃ¦isk-pÃ¦dagogisk-tesaurus   Subject-controlled,Subject-controlled
 elm 661/?/a     Kontrolleret-dansk-emneord      Subject-controlled,Subject-controlled
 elm 661/?/b     Kontrolleret-engelsk-emneord    Subject-controlled,Subject-controlled
 elm 661/?/c     Ukontrolleret-dansk-emneord     Subject-controlled,Subject-controlled
@@ -543,17 +543,17 @@ elm 661/?/c     Ukontrolleret-dansk-emneord     Subject-controlled,Subject-contr
 elm 666         Kontrolleret-DBC-emneord            -
 elm 666/?       Kontrolleret-DBC-emneord            -
 elm 666/?/e     Stednavn-som-emneord-faglitteratur  Subject-DBC,Subject-controlled,Subject-DBC-non-fiction,Subject-controlled
-elm 666/?/f     Kontrolleret-faglitterært-emneord   Subject-DBC,Subject-controlled,Subject-DBC-non-fiction,Subject-controlled
+elm 666/?/f     Kontrolleret-faglitterÃ¦rt-emneord   Subject-DBC,Subject-controlled,Subject-DBC-non-fiction,Subject-controlled
 elm 666/?/i     Tidsangivelse                       Subject-DBC,Subject-controlled,Subject-DBC-non-fiction,Subject-controlled
 elm 666/?/l     Stednavn                            Subject-DBC,Subject-controlled
 elm 666/?/m     Musikalsk-genre-som-emneord         Subject-DBC,Subject-controlled,Subject-DBC-music
-elm 666/?/n     Musikalsk-besætning-som-emneord     Subject-DBC,Subject-controlled,Subject-DBC-music
+elm 666/?/n     Musikalsk-besÃ¦tning-som-emneord     Subject-DBC,Subject-controlled,Subject-DBC-music
 elm 666/?/o     Formbetegnelse                      Subject-DBC,Subject-controlled,Form-as-subject
 elm 666/?/p     Periodebetegnelse                   Subject-DBC,Subject-controlled,Subject-DBC-music
-elm 666/?/q     Stednavn-som-emneord-skønlitteratur Subject-DBC,Subject-controlled,Subject-DBC-fiction,Subject-controlled
-elm 666/?/s     Kontrolleret-skønlitterært-emneord  Subject-DBC,Subject-controlled,Subject-DBC-fiction,Subject-controlled
+elm 666/?/q     Stednavn-som-emneord-skÃ¸nlitteratur Subject-DBC,Subject-controlled,Subject-DBC-fiction,Subject-controlled
+elm 666/?/s     Kontrolleret-skÃ¸nlitterÃ¦rt-emneord  Subject-DBC,Subject-controlled,Subject-DBC-fiction,Subject-controlled
 elm 666/?/u     Niveau/brugerkategori               Subject-DBC,Subject-controlled,Level-as-subject
-elm 666/?/å     Kontrolleret-DBC-emneord            Subject-DBC,Subject-controlled
+elm 666/?/Ã¥     Kontrolleret-DBC-emneord            Subject-DBC,Subject-controlled
 
 elm 668         Genrebetegnelse         -
 elm 668/?       Genrebetegnelse         Subject-controlled
@@ -584,22 +584,22 @@ elm 700/?       Personnavn              Personal-name
 elm 700/?/A     Personnavn              Personal-name
 elm 700/?/a     Efternavn/fornavn-alene Personal-name
 elm 700/?/b     Funktionsbetegnelse -
-elm 700/?/c     Fødselsår               Personal-name
-elm 700/?/f     Tilføjelse              Personal-name
+elm 700/?/c     FÃ¸dselsÃ¥r               Personal-name
+elm 700/?/f     TilfÃ¸jelse              Personal-name
 elm 700/?/h     Fornavn                 Personal-name
 elm 700/?/k     Fuldt-udskrevet-fornavn Personal-name
-elm 700/?/å     Personnavn              -
+elm 700/?/Ã¥     Personnavn              -
 
 elm 710         Korporationsnavn        -
 elm 710/?       Korporationsnavn        Personal-name
 elm 710/?/A     Korporationsnavn        Personal-name
 elm 710/?/a     Korporationsnavn        Personal-name
 elm 710/?/c     Underkorporation        Personal-name
-elm 710/?/e     Tilføjelse              Personal-name
-elm 710/?/i     Nummer-på-konference    Personal-name
+elm 710/?/e     TilfÃ¸jelse              Personal-name
+elm 710/?/i     Nummer-pÃ¥-konference    Personal-name
 elm 710/?/j     Sted-for-konference     Personal-name
-elm 710/?/k     År-for-konference       Personal-name
-elm 710/?/å     Korporationsnavn        -
+elm 710/?/k     Ã…r-for-konference       Personal-name
+elm 710/?/Ã¥     Korporationsnavn        -
 
 
 elm 739         Uniform-titel/standardtitel -
@@ -609,27 +609,27 @@ elm 739/?/t     Uniform-titel/standardtitel Title-uniform
 elm 740         Uniform-titel                -
 elm 740/?       Uniform-titel                Title,Title-uniform
 elm 740/?/a     Uniform-titel                Title,Title-uniform
-elm 740/?/s     Titel-på-del-af-værket       Title,Title-uniform
+elm 740/?/s     Titel-pÃ¥-del-af-vÃ¦rket       Title,Title-uniform
 
 elm 745         Varianttitel            -
 elm 745/?       Varianttitel            -
 elm 745/?/A     Varianttitel            -
 elm 745/?/a     Titel                   Title
-elm 745/?/o     Titel-på-afhængig-publikation/supplement    -
+elm 745/?/o     Titel-pÃ¥-afhÃ¦ngig-publikation/supplement    -
 
 elm 770         Personnavn-analyse      -
 elm 770/?       Personnavn-analyse      Personal-name
 elm 770/?/A     Personnavn-analyse      -
 elm 770/?/a     Efternavn/fornavn-alene Personal-name
-elm 770/?/c     Fødselsår               Personal-name
-elm 770/?/f     Tilføjelse              Personal-name
+elm 770/?/c     FÃ¸dselsÃ¥r               Personal-name
+elm 770/?/f     TilfÃ¸jelse              Personal-name
 elm 770/?/h     Fornavn                 Personal-name
-elm 770/?/å     Feltnumerator           -
+elm 770/?/Ã¥     Feltnumerator           -
 
 elm 780         Korporationsnavn-analyse    -
 elm 780/?       Korporationsnavn-analyse    Personal-name,Corporate-name
 elm 780/?/a     Korporationsnavn            Personal-name,Corporate-name
-elm 780/?/å     Feltnumerator               Personal-name,Corporate-name
+elm 780/?/Ã¥     Feltnumerator               Personal-name,Corporate-name
 
 elm 795         Analytisk-titel                             -
 elm 795/?       Analytisk-titel                             Title
@@ -638,12 +638,12 @@ elm 795/?/a     Analytisk-titel                             Title
 elm 795/?/b     Rest-af-analytisk-titel/alternativ-titel    Title
 elm 795/?/c     Undertitel/anden-titelinformation           Title
 elm 795/?/e     Ophavsangivelse-opslag                      -
-elm 795/?/i     Anden-primær/sekundær-ophavsangivelse       -
+elm 795/?/i     Anden-primÃ¦r/sekundÃ¦r-ophavsangivelse       -
 elm 795/?/p     Paralleltitel                               Title
 elm 795/?/u     Almindeligt-kendt-tilnavn                   Title
 elm 795/?/v     Uddragstitel                                Title
 elm 795/?/y     Kode                                        -
-elm 795/?/å     Feltnumerator                               -
+elm 795/?/Ã¥     Feltnumerator                               -
 
 elm 840         Serietitel              -
 elm 840/?       Serietitel              -
@@ -651,17 +651,17 @@ elm 840/?/V     Serietitel              -
 elm 840/?/a     Seriens-hovedtitel              Title,Title-series
 elm 840/?/v     Seriens-nummerering/datering    Title,Title-series
 elm 840/?/z     Seriens-ISSN                    Identifier-standard,ISSN,Item-number
-elm 840/?/ø     Identificerende-tilføjelser-til-seriens-titel   Title
+elm 840/?/Ã¸     Identificerende-tilfÃ¸jelser-til-seriens-titel   Title
 
 elm 860         Tidligere-titel         -
 elm 860/?       Tidligere-titel         -
-elm 860/?/c     Tilføjelse-til-titel    Related-periodical,Title-former
+elm 860/?/c     TilfÃ¸jelse-til-titel    Related-periodical,Title-former
 elm 860/?/t     Hovedtitel              Title-former
 elm 860/?/z     ISSN                    Identifier-standard,ISSN,Item-number
 
 elm 861         Senere-titel            -
 elm 861/?       Senere-titel            -
-elm 861/?/c     Tilføjelse-til-titel    Related-periodical,Title-added-title-page
+elm 861/?/c     TilfÃ¸jelse-til-titel    Related-periodical,Title-added-title-page
 elm 861/?/i     Indledende-tekst       -
 elm 861/?/t     Hovedtitel              Related-periodical,Title-added-title-page
 elm 861/?/z     ISSN                    Identifier-standard,ISSN,Item-number
@@ -671,13 +671,13 @@ elm 863/?       Udgivet-sammen-med      -
 elm 863/?/t     Hovedtitel              Title-other-variant
 elm 863/?/z     ISSN                    Identifier-standard,ISSN,Item-number
 
-elm 867         Hovedudgave-på-andet-sprog/andet-indhold    -
-elm 867/?       Hovedudgave-på-andet-sprog/andet-indhold    -
+elm 867         Hovedudgave-pÃ¥-andet-sprog/andet-indhold    -
+elm 867/?       Hovedudgave-pÃ¥-andet-sprog/andet-indhold    -
 elm 867/?/t     Hovedtitel                                  Title-other-variant
 elm 867/?/z     ISSN                                        Identifier-standard,ISSN,Item-number
 
-elm 868         Udgave-på-andet-sprog/andet-indhold     -
-elm 868/?       Udgave-på-andet-sprog/andet-indhold     -
+elm 868         Udgave-pÃ¥-andet-sprog/andet-indhold     -
+elm 868/?       Udgave-pÃ¥-andet-sprog/andet-indhold     -
 elm 868/?/t     Hovedtitel                              Title-other-variant
 elm 868/?/z     ISSN                                    Identifier-standard,ISSN,Item-number
 
@@ -688,7 +688,7 @@ elm 870/?/z     ISSN                                Identifier-standard,ISSN,Ite
 
 elm 871         Supplement-til-hovedpublikation     -
 elm 871/?       Supplement-til-hovedpublikation     -
-elm 871/?/c     Tilføjelse-til-titel                -
+elm 871/?/c     TilfÃ¸jelse-til-titel                -
 elm 871/?/t     Hovedtitel                          Title-other-variant
 
 elm 874         Underserie              -
@@ -700,27 +700,27 @@ elm 900         Henvisning-fra-personnavn   -
 elm 900/?       Henvisning-fra-personnavn   Personal-name
 elm 900/?/A     Henvisning-fra-personnavn   -
 elm 900/?/a     Efternavnet/fornavnet-alene Personal-name
-elm 900/?/c     Fødselsår                   Personal-name
-elm 900/?/f     Tilføjelse                  Personal-name
+elm 900/?/c     FÃ¸dselsÃ¥r                   Personal-name
+elm 900/?/f     TilfÃ¸jelse                  Personal-name
 elm 900/?/h     Fornavn                     Personal-name
 elm 900/?/k     Fuldt-udskrevet-fornavn     Personal-name
 elm 900/?/w     Ord-hvortil-der-henvises    -
 elm 900/?/x     Forbindende-tekst           -
 elm 900/?/z     Felt/delfeltkode-hvortil-der-henvises   -
-elm 900/?/å     Feltnumerator               -
+elm 900/?/Ã¥     Feltnumerator               -
 
 elm 910         Henvisning-fra-korporationsnavn     -
 elm 910/?       Henvisning-fra-korporationsnavn     Personal-name
 elm 910/?/A     Henvisning-fra-korporationsnavn     -
 elm 910/?/a     Korporationsnavn                    Personal-name
 elm 910/?/c     Underkorporation                    Personal-name
-elm 910/?/e     Tilføjelse                          Personal-name
+elm 910/?/e     TilfÃ¸jelse                          Personal-name
 elm 910/?/g     Resten-af-korporationsnavn          Personal-name
 elm 910/?/h     Forbogstaver/fornavnsforkortelser   Personal-name
 elm 910/?/w     Ord-hvortil-der-henvises            -
 elm 910/?/x     Forbindende-tekst                   -
 elm 910/?/z     Felt/delfeltkode-hvortil-der-henvises     -
-elm 910/?/å     Feltnumerator                       -
+elm 910/?/Ã¥     Feltnumerator                       -
 
 elm 945         Henvisning-fra-titel        -
 elm 945/?       Henvisning-fra-titel        -
@@ -731,8 +731,8 @@ elm 945/?/z     Felt/delfeltkode-hvortil-der-henvises        -
 
 elm 980         Bibliotekets-beholdning-af-et-periodicum    -
 elm 980/?       Bibliotekets-beholdning-af-et-periodicum    -
-elm 980/?/d     Første-år                                   -
-elm 980/?/g     Kode-for-fuldstændighed                     -
+elm 980/?/d     FÃ¸rste-Ã¥r                                   -
+elm 980/?/g     Kode-for-fuldstÃ¦ndighed                     -
 
 elm s01         felt-s01                    -
 elm s01/?       felt-s01                    -

--- a/tab/scan.chr
+++ b/tab/scan.chr
@@ -4,8 +4,8 @@
 # Define the basic value-set. *Beware* of changing this without re-indexing
 # your databases.
 
-lowercase {0-9}{a-y}üzæäøöå
-uppercase {0-9}{A-Y}ÜZÆÄØÖÅ
+lowercase {0-9}{a-y}Ã¼zÃ¦Ã¤Ã¸Ã¶Ã¥
+uppercase {0-9}{A-Y}ÃœZÃ†Ã„Ã˜Ã–Ã…
 
 # Breaking characters
 
@@ -13,28 +13,28 @@ space {\001-\040}!"#$%&'\()*+,-./:;<=>?@\[\\]^_`\{|}~
 
 # Characters to be considered equivalent for searching purposes.
 
-# equivalent æä(ae)
-# equivalent øö(oe)
-# equivalent å(aa)
-# equivalent uü
+# equivalent Ã¦Ã¤(ae)
+# equivalent Ã¸Ã¶(oe)
+# equivalent Ã¥(aa)
+# equivalent uÃ¼
 
 # Supplemental mappings
 
-map (&auml;)       ä
-map (&aelig;)      æ
-map (&oslash;)     ø
-map (&aring;)      å
-map (&ouml;)       ö
-map (&Auml;)       Ä
-map (&Aelig;)      Æ
-map (&Oslash;)     Ø
-map (&Aring;)      Å
-map (&Ouml;)       Ö
+map (&auml;)       Ã¤
+map (&aelig;)      Ã¦
+map (&oslash;)     Ã¸
+map (&aring;)      Ã¥
+map (&ouml;)       Ã¶
+map (&Auml;)       Ã„
+map (&Aelig;)      Ã†
+map (&Oslash;)     Ã˜
+map (&Aring;)      Ã…
+map (&Ouml;)       Ã–
 
-map éÉ		e
-map á		a
-map ó		o
-map í		i
+map Ã©Ã‰		e
+map Ã¡		a
+map Ã³		o
+map Ã­		i
 
 map (Aa)	(AA)
 

--- a/tab/string.chr
+++ b/tab/string.chr
@@ -4,8 +4,8 @@
 # Define the basic value-set. *Beware* of changing this without re-indexing
 # your databases.
 
-lowercase {0-9}{a-y}üzæäøöå
-uppercase {0-9}{A-Y}ÜZÆÄØÖÅ
+lowercase {0-9}{a-y}Ã¼zÃ¦Ã¤Ã¸Ã¶Ã¥
+uppercase {0-9}{A-Y}ÃœZÃ†Ã„Ã˜Ã–Ã…
 
 # Breaking characters
 
@@ -13,28 +13,28 @@ space {\001-\040}!"#$%&'\()*+,-./:;<=>?@\[\\]^_`\{|}~
 
 # Characters to be considered equivalent for searching purposes.
 
-# equivalent æä(ae)
-# equivalent øö(oe)
-# equivalent å(aa)
-# equivalent uü
+# equivalent Ã¦Ã¤(ae)
+# equivalent Ã¸Ã¶(oe)
+# equivalent Ã¥(aa)
+# equivalent uÃ¼
 
 # Supplemental mappings
 
-#map (&auml;)       ä
-#map (&aelig;)      æ
-#map (&oslash;)     ø
-#map (&aring;)      å
-#map (&ouml;)       ö
-#map (&Auml;)       Ä
-#map (&Aelig;)      Æ
-#map (&Oslash;)     Ø
-#map (&Aring;)      Å
-#map (&Ouml;)       Ö
+#map (&auml;)       Ã¤
+#map (&aelig;)      Ã¦
+#map (&oslash;)     Ã¸
+#map (&aring;)      Ã¥
+#map (&ouml;)       Ã¶
+#map (&Auml;)       Ã„
+#map (&Aelig;)      Ã†
+#map (&Oslash;)     Ã˜
+#map (&Aring;)      Ã…
+#map (&Ouml;)       Ã–
 
-#map éÉ		e
-#map á		a
-#map ó		o
-#map í		i
+#map Ã©Ã‰		e
+#map Ã¡		a
+#map Ã³		o
+#map Ã­		i
 
 #map (Aa)	(AA)
 

--- a/tab/urx.chr
+++ b/tab/urx.chr
@@ -3,8 +3,8 @@
 
 # Basic character(s)
 
-lowercase {0-9}{a-y}üzæäøöå/.~:-,#!?=<;\{|}+
-uppercase {0-9}{A-Y}ÜZÆÄØÖÅ/.~:-,#!?=>;\{|}+
+lowercase {0-9}{a-y}Ã¼zÃ¦Ã¤Ã¸Ã¶Ã¥/.~:-,#!?=<;\{|}+
+uppercase {0-9}{A-Y}ÃœZÃ†Ã„Ã˜Ã–Ã…/.~:-,#!?=>;\{|}+
 
 # Breaking characters
 


### PR DESCRIPTION
This patchset converts some files encoded in ISO-8859-1 to UTF-8.

Found while packaging Debian version 2.2.0-1.