### PR TITLE
Require yaz libraries for pkg-config and fix a typo in configure.ac

### DIFF
--- a/configure.ac
+++ b/configure.ac
@@ -121,7 +121,7 @@ else
     ZINT_VALUE=0
 fi 
 ZEBRA_CFLAGS="-DZEBRA_ZINT=${ZINT_VALUE}"
-AC_DEFINE_UNQUOTED([ZEBRA_ZINT],${ZINT_VALUE},[Whehter zint is long long])
+AC_DEFINE_UNQUOTED([ZEBRA_ZINT],${ZINT_VALUE},[Whether zint is long long])
 dnl ------ Modules
 AC_SUBST([SHARED_MODULE_LA])
 SHARED_MODULE_LA=""

--- a/zebra.pc.in
+++ b/zebra.pc.in
@@ -9,6 +9,7 @@ tab=@datarootdir@/idzebra@PACKAGE_SUFFIX@/tab
 Name: Zebra
 Version: @VERSION@
 Description: Indexing and retrieval engine for structured text. 
+Requires: yaz yaz-icu yaz-server
 Libs: -L${libdir} -lidzebra-2.0 @YAZLIB@ @TCL_LIBS@ @EXPAT_LIBS@
 Libs.private: @LIBS@
 Cflags: -I${includedir} -I${includedir}/idzebra@PACKAGE_SUFFIX@ @ZEBRA_CFLAGS@

--- a/zebra.pc.in
+++ b/zebra.pc.in
@@ -8,7 +8,7 @@ tab=@datarootdir@/idzebra@PACKAGE_SUFFIX@/tab
 
 Name: Zebra
 Version: @VERSION@
-Description: Indexing and retrieval engine for structured text. 
+Description: Indexing and retrieval engine for structured text.
 Requires: yaz yaz-icu yaz-server
 Libs: -L${libdir} -lidzebra-2.0 @YAZLIB@ @TCL_LIBS@ @EXPAT_LIBS@
 Libs.private: @LIBS@


### PR DESCRIPTION
With the Requires line, pkg-config checks for the existence of yaz if run via `pkg-config --libs zebra` or similar.

There's also a typo in configure.ac.