### PR TITLE
Fix tests failing when running with make -j4 check

### DIFF
--- a/dict/Makefile.am
+++ b/dict/Makefile.am
@@ -25,7 +25,6 @@ dictext_SOURCES = dictext.c
 
 scantest_SOURCES = scantest.c
 
-
 clean-local:
 	-rm -rf *.LCK 
 	-rm -rf *.log 

--- a/dict/inserttest.c
+++ b/dict/inserttest.c
@@ -46,7 +46,7 @@ int main(int argc, char **argv)
     if (bfs)
     {
         bf_reset(bfs);
-        dict = dict_open(bfs, "dict", 50, 1, 0, 4096);
+        dict = dict_open(bfs, "inserttest", 50, 1, 0, 4096);
         YAZ_CHECK(dict);
     }
 

--- a/dict/scantest.c
+++ b/dict/scantest.c
@@ -285,7 +285,7 @@ int main(int argc, char **argv)
     if (bfs)
     {
         bf_reset(bfs);
-        dict = dict_open(bfs, "dict", 100, 1, 0, 0);
+        dict = dict_open(bfs, "scantest", 100, 1, 0, 0);
         YAZ_CHECK(dict);
     }
     if (dict)


### PR DESCRIPTION
Fixed by creating separate .mf files.