### PR TITLE
index: Add missing stdlib.h inclusions (mod_alvis, mod_dom)

### DIFF
--- a/index/mod_alvis.c
+++ b/index/mod_alvis.c
@@ -21,6 +21,7 @@ Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA  02110-1301  USA
 #include <config.h>
 #endif
 #include <stdio.h>
+#include <stdlib.h>
 #include <assert.h>
 #include <ctype.h>
 

--- a/index/mod_dom.c
+++ b/index/mod_dom.c
@@ -21,6 +21,7 @@ Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA  02110-1301  USA
 #include <config.h>
 #endif
 #include <stdio.h>
+#include <stdlib.h>
 #include <assert.h>
 #include <ctype.h>
 #include <stdarg.h>


### PR DESCRIPTION
Debian now builds with -Werror=implicit-function-declaration, meaning Zebra fails to build from source due to missing stdlib.h inclusions.