### PR TITLE
Upgrade to debhelper 13

### DIFF
--- a/debian/idzebra-2.0-utils.manpages
+++ b/debian/idzebra-2.0-utils.manpages
@@ -1,3 +1,3 @@
-usr/share/man/man8/zebrasrv*
-usr/share/man/man1/zebraidx*
-usr/share/man/man1/idzebra-abs2dom*
+doc/zebrasrv-2.0.8
+doc/zebraidx-2.0.1
+doc/idzebra-abs2dom.1

--- a/debian/libidzebra-2.0-dev.manpages
+++ b/debian/libidzebra-2.0-dev.manpages
@@ -1,1 +1,1 @@
-usr/share/man/man1/idzebra-config*
+doc/idzebra-config-2.0.1

--- a/debian/not-installed
+++ b/debian/not-installed
@@ -4,3 +4,4 @@ usr/lib/*/idzebra-2.0/modules/mod*.la
 usr/lib/*/idzebra-2.0/modules/mod*.a
 usr/lib/*/idzebra-2.0/modules/mod-safari*
 usr/lib/*/lib*.la
+usr/share/man/man*/*


### PR DESCRIPTION
Debian bullseye is 13, the earliest supported version.